### PR TITLE
feat: add Tailscale funnel sidecar for secure external access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,13 @@
 # Use Node.js (full image for Cloudflare workerd compatibility)
 FROM node:22-slim
 
-# Set the working directory in the container
 WORKDIR /app
 
-# Copy package files and install dependencies
 COPY package.json package-lock.json* ./
 RUN npm ci
 
-# Copy the rest of the application code
 COPY . .
 
-# Expose the port the app will run on
-EXPOSE 5050
-
-# Set the host to allow external connections
 ENV HOST=0.0.0.0
 
-# Run the Astro development server
 CMD ["npx", "astro", "dev", "--host", "--port", "5050"]

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,5 +25,8 @@ export default defineConfig({
     ssr: {
       external: ['node:buffer'],
     },
+    server: {
+      allowedHosts: ['staticfish-1.silverside-gopher.ts.net'],
+    },
   },
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     env_file:
       - .env
     container_name: staticfish-astro
-    ports:
-      - "5050:5050"
     restart: unless-stopped
     environment:
       - NODE_ENV=development
@@ -28,7 +26,38 @@ services:
       - ./tailwind.config.js:/app/tailwind.config.js:ro
       - ./sanity.config.ts:/app/sanity.config.ts:ro
       - ./sanity.cli.ts:/app/sanity.cli.ts:ro
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.staticfish.rule=Host(`staticfish.local`)"
-      - "traefik.http.services.staticfish.loadbalancer.server.port=5050"
+    networks:
+      - staticfish-net
+
+  tailscale:
+    image: tailscale/tailscale:latest
+    container_name: staticfish-tailscale
+    hostname: ${TS_HOSTNAME:-staticfish}
+    depends_on:
+      - staticfish-astro
+    networks:
+      - staticfish-net
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY}
+      - TS_STATE_DIR=/var/lib/tailscale
+      - TS_USERSPACE=false
+      - TS_AUTH_ONCE=true
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    command: >
+      sh -c "tailscaled &
+        sleep 5 &&
+        tailscale up --authkey=$${TS_AUTHKEY} --reset &&
+        tailscale funnel --bg --https 443 http://staticfish-astro:5050 &&
+        tail -f /dev/null"
+    restart: unless-stopped
+
+networks:
+  staticfish-net:
+
+volumes:
+  tailscale-state:


### PR DESCRIPTION
## Summary
- Adds Tailscale sidecar container with Funnel for public HTTPS access
- Removes exposed port 5050 (no host ports needed)
- Adds Vite `allowedHosts` config for funnel domain

The dev site is now accessible at `https://staticfish-1.silverside-gopher.ts.net/` without opening any host ports.

Requires `TS_AUTHKEY` in `.env`.