### PR TITLE
Add Kernel MCP to OpenCode config

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -5,6 +5,14 @@
       "type": "local",
       "command": ["npx", "chrome-devtools-mcp@latest", "--executablePath", "/home/micqdf/.nix-profile/bin/chromium"],
       "enabled": true
+    },
+    "kernel": {
+      "type": "remote",
+      "url": "https://mcp.onkernel.com/mcp",
+      "headers": {
+        "Authorization": "Bearer {env:KERNEL_API_KEY}"
+      },
+      "enabled": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a remote  MCP server entry to 
- configure auth header to read  from environment
- keep existing Chrome DevTools MCP entry unchanged

## Why
- enables direct Kernel tooling access in OpenCode sessions via project config