### PR TITLE
Add Chattybox chat widget

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="astro/client" />
 
+interface ImportMetaEnv {
+  readonly PUBLIC_CHATTYBOX_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare namespace App {
   interface Locals {
     cspNonce: string;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,8 @@ export interface Props {
 }
 
 const { title, description = "Professional web development for small businesses. Fixed pricing, fast delivery, no hidden costs." } = Astro.props;
+
+const chattyboxKey = import.meta.env.PUBLIC_CHATTYBOX_KEY;
 ---
 
 <!doctype html>
@@ -27,6 +29,12 @@ const { title, description = "Professional web development for small businesses.
     <link rel="canonical" href={Astro.url} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title}</title>
+    <script
+      src="https://chattybox.ai/widget.js"
+      data-api-key={chattyboxKey}
+      data-api-url="https://adorable-woodpecker-629.convex.site/chat"
+      async
+    ></script>
   </head>
   <body>
     <slot />


### PR DESCRIPTION
Adds the Chattybox chat widget script to the site layout `<head>` so it loads on every page.

- Widget script loaded async from `chattybox.ai/widget.js`
- Public client API key (`cb_` prefix) embedded directly — safe to expose, like a Stripe publishable key